### PR TITLE
Added VS Code tasks (including debugging support)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "cppvsdbg",
+            "request": "launch",
+            "preLaunchTask": "build_debug",
+            "name": "Debug",
+            "program": "${workspaceFolder}/game_debug.exe",
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "cppvsdbg",
+            "request": "launch",
+            "preLaunchTask": "build_release",
+            "name": "Release",
+            "program": "${workspaceFolder}/game_release.exe",
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "cppvsdbg",
+            "request": "launch",
+            "name": "Run File",
+            "program": "odin",
+            "args": ["run", "${fileBasename}", "-file"],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+    "version": "2.0.0",
+    "command": "",
+    "args": [],
+    "tasks": [
+        {
+            "label": "build_debug",
+            "type": "shell",
+            "command": "${workspaceFolder}/build_debug.bat",
+            "group": "build"
+        },
+        {
+            "label": "build_release",
+            "type": "shell",
+            "command": "${workspaceFolder}/build_release.bat",
+            "group": "build"
+        },
+        {
+            "label": "Build Hot Reload",
+            "type": "shell",
+            "command": "${workspaceFolder}/build_hot_reload.bat; start game.exe",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": false,
+                "clear": true
+            },
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ There are also some additional files with some helpers that I find useful.
 ## Sublime
 There's a `project.sublime-project` in case you use sublime. Edit it and make sure the paths to the folders within the Odin compiler directory are correct. I put those as part of my project so I can quickly jump to symbols within core & raylib.
 
+## VS Code
+Included there are Debug and Release tasks for VS Code. If you install the [CodeLLDB](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) extension, it's possible to Debug the project code with the included Debug task.
+
+A task to build and hot reload is also included, build, run and rebuild with `Ctrl+B` or `Command Palette` -> `Task: Run Build Task`.
+
 ## Questions?
 
 Ask questions in my gamedev Discord: https://discord.gg/4FsHgtBmFK

--- a/build_debug.bat
+++ b/build_debug.bat
@@ -1,0 +1,2 @@
+@echo off
+odin build main_release -define:RAYLIB_SHARED=false -out:game_debug.exe -no-bounds-check -subsystem:windows -debug


### PR DESCRIPTION
Added VS Code tasks, as well a new build script `build_debug.bat` for debugging with VS Code.

# Tasks
- Added a Release and Debug VS Code tasks.
- Added a Hot Reload VS Code task (which simply makes use of the existing `build_hot_reload.bat` script).

## Debug
Added a task for debugging the project, with breakpoint support (even the core library and raylib can be debugged alongside the project code, for example). Requires the [CodeLLDB ](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb) extension.

![image](https://github.com/karl-zylinski/odin-raylib-hot-reload-game-template/assets/248383/804350ec-1b77-4fc6-bec9-023cc0a2e240)

## Hot Reload
Build, run and rebuild with `Ctrl+B`. Or Command Palette -> Task: Run Build Task.

![image](https://github.com/karl-zylinski/odin-raylib-hot-reload-game-template/assets/248383/0f2559bb-4121-4290-a406-9ebaaf0b3e86)
