### PR TITLE
Removed redundant os.close call from the end of main_release

### DIFF
--- a/main_release/main_release.odin
+++ b/main_release/main_release.odin
@@ -60,7 +60,6 @@ main :: proc() {
 	
 	if logh_err == os.ERROR_NONE {
 		log.destroy_file_logger(&logger)
-		os.close(logh)
 	}
 
 	when UseTrackingAllocator {


### PR DESCRIPTION
Removes the `os.close(logh)` call at the end of `main_release.odin`.

`main_release.odin` currently calls:
```odin
log.destroy_file_logger(&logger)
os.close(logh)
```

But `destroy_file_logger` already closes the file handle:
```odin
destroy_file_logger :: proc(log: ^Logger) {
	data := cast(^File_Console_Logger_Data)log.data
	if data.file_handle != os.INVALID_HANDLE {
		os.close(data.file_handle) <-------------------------
	}
	free(data)
}
```
The extra call `os.close(logh)` is crashing the application upon being closed:

```
game_debug.exe: An invalid handle was specified.
```

![image](https://github.com/karl-zylinski/odin-raylib-hot-reload-game-template/assets/248383/a2c4a9b6-97e0-47d9-81c9-08f5a712fde8)

