### PR TITLE
Fix VS Code task name case

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
         {
             "type": "cppvsdbg",
             "request": "launch",
-            "preLaunchTask": "build_debug",
+            "preLaunchTask": "Build Debug",
             "name": "Debug",
             "program": "${workspaceFolder}/game_debug.exe",
             "args": [],
@@ -13,7 +13,7 @@
         {
             "type": "cppvsdbg",
             "request": "launch",
-            "preLaunchTask": "build_release",
+            "preLaunchTask": "Build Release",
             "name": "Release",
             "program": "${workspaceFolder}/game_release.exe",
             "args": [],


### PR DESCRIPTION
Fix a regression introduced by #6, which [changed the task labels' case](https://github.com/karl-zylinski/odin-raylib-hot-reload-game-template/pull/6/files#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aL7) but did not reflect the changes in `launch.json`.

![image](https://github.com/karl-zylinski/odin-raylib-hot-reload-game-template/assets/248383/ef6f031c-04ea-4a25-be41-d022e47f0358)
