### PR TITLE
Update Atlas Builder to support animations based on tags

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,7 +1,0 @@
-// Folder-specific settings
-//
-// For a full list of overridable settings, and general information on folder-specific settings,
-// see the documentation: https://zed.dev/docs/configuring-zed#folder-specific-settings
-{
-  "hard_tabs": true
-}

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,7 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#folder-specific-settings
+{
+  "hard_tabs": true
+}

--- a/atlas_builder/atlas_builder.odin
+++ b/atlas_builder/atlas_builder.odin
@@ -242,13 +242,13 @@ load_ase_texture_data :: proc(filename: string, textures: ^[dynamic]Texture_Data
 				
 			case ase.Tags_Chunk:
 				for tag in c {
-                    a := Animation {
-             			name = fmt.tprint(base_name, tag.name, sep = "_"),
-             			first_texture = fmt.tprint(base_name, tag.from_frame, sep = ""),
-             			last_texture = fmt.tprint(base_name, tag.to_frame, sep = ""),
-                    }
-                    append(animations, a)
-                }
+					a := Animation {
+						name = fmt.tprint(base_name, tag.name, sep = "_"),
+						first_texture = fmt.tprint(base_name, tag.from_frame, sep = ""),
+						last_texture = fmt.tprint(base_name, tag.to_frame, sep = ""),
+					}
+					append(animations, a)
+				}
 			}
 		}
 

--- a/atlas_builder/atlas_builder.odin
+++ b/atlas_builder/atlas_builder.odin
@@ -239,6 +239,16 @@ load_ase_texture_data :: proc(filename: string, textures: ^[dynamic]Texture_Data
 					cel_max.y = max(cel_max.y, int(c.y) + int(cl.height))
 					append(&cels, &c)
 				}
+				
+			case ase.Tags_Chunk:
+				for tag in c {
+                    a := Animation {
+             			name = fmt.tprint(base_name, tag.name, sep = "_"),
+             			first_texture = fmt.tprint(base_name, tag.from_frame, sep = ""),
+             			last_texture = fmt.tprint(base_name, tag.to_frame, sep = ""),
+                    }
+                    append(animations, a)
+                }
 			}
 		}
 


### PR DESCRIPTION
Aseprite allows to mark frames with tags. This allows to have a single file with multiple separate animations - e.g.
![Zrzut ekranu z 2024-08-02 22-45-58](https://github.com/user-attachments/assets/4583a217-f689-432f-abf1-e5c62b2b6321)
see [Aseprite docs](https://www.aseprite.org/docs/tags/) for more details

This change generates a separate Animation_Name in atlas.odin for each tag found in ase file (with appropriate frame numbers). E.g.
![Zrzut ekranu z 2024-08-02 22-33-53](https://github.com/user-attachments/assets/57c18ddf-b29d-4775-9272-abc58226d9c8)
