### PR TITLE
Atlas builder - support for repeat and loop dir properties of animation tags

### DIFF
--- a/atlas_builder/atlas_builder.odin
+++ b/atlas_builder/atlas_builder.odin
@@ -25,6 +25,9 @@ import rl "vendor:raylib"
 TILESET_WIDTH :: 10
 TILE_SIZE :: 10
 
+PACKAGE_NAME :: "game"
+TEXTURES_DIR :: "textures"
+
 dir_path_to_file_infos :: proc(path: string) -> []os.File_Info {
 	d, derr := os.open(path, os.O_RDONLY)
 	if derr != 0 {
@@ -174,6 +177,8 @@ Animation :: struct {
 	name: string,
 	first_texture: string,
 	last_texture: string,
+	loop_direction: ase.Tag_Loop_Dir,
+	repeat: u16,
 }
 
 load_ase_texture_data :: proc(filename: string, textures: ^[dynamic]Texture_Data, animations: ^[dynamic]Animation) {
@@ -242,13 +247,16 @@ load_ase_texture_data :: proc(filename: string, textures: ^[dynamic]Texture_Data
 				
 			case ase.Tags_Chunk:
 				for tag in c {
-					a := Animation {
-						name = fmt.tprint(base_name, tag.name, sep = "_"),
-						first_texture = fmt.tprint(base_name, tag.from_frame, sep = ""),
-						last_texture = fmt.tprint(base_name, tag.to_frame, sep = ""),
-					}
-					append(animations, a)
-				}
+				    fmt.println(tag)
+                    a := Animation {
+             			name = fmt.tprint(base_name, tag.name, sep = "_"),
+             			first_texture = fmt.tprint(base_name, tag.from_frame, sep = ""),
+             			last_texture = fmt.tprint(base_name, tag.to_frame, sep = ""),
+                        loop_direction = tag.loop_direction,
+                        repeat = tag.repeat,
+                    }
+                    append(animations, a)
+                }
 			}
 		}
 
@@ -394,7 +402,7 @@ main :: proc() {
 	textures: [dynamic]Texture_Data
 	animations: [dynamic]Animation
 
-	file_infos := dir_path_to_file_infos("textures")
+	file_infos := dir_path_to_file_infos(TEXTURES_DIR)
 
 	slice.sort_by(file_infos, proc(i, j: os.File_Info) -> bool {
 		return time.diff(i.creation_time, j.creation_time) > 0
@@ -406,7 +414,7 @@ main :: proc() {
 		is_ase := strings.has_suffix(fi.name, ".ase") || strings.has_suffix(fi.name, ".aseprite")
 		is_png := strings.has_suffix(fi.name, ".png")
 		if is_ase || is_png {
-			path := fmt.tprintf("textures/%s", fi.name)
+			path := fmt.tprintf("%s/%s", TEXTURES_DIR, fi.name)
 			if strings.has_prefix(fi.name, "tileset") {
 				load_tileset(path, &tileset)
 			} else if is_ase {
@@ -719,9 +727,9 @@ main :: proc() {
 	f, _ := os.open("atlas.odin", os.O_WRONLY | os.O_CREATE | os.O_TRUNC)
 	defer os.close(f)
 
-	fmt.fprintln(f, "package game")
+	fmt.fprintf(f, "package %s\n", PACKAGE_NAME)
 	fmt.fprintln(f, "")
-
+	
 	fmt.fprintln(f, "Texture_Name :: enum {")
 	fmt.fprint(f, "\tNone,\n")
 	for r in atlas_textures {
@@ -793,9 +801,18 @@ main :: proc() {
 	fmt.fprintln(f, "}")
 	fmt.fprintln(f, "")
 
+	fmt.fprintln(f, "Tag_Loop_Dir :: enum {")
+	fmt.fprintln(f, "\tForward,")
+	fmt.fprintln(f, "\tReverse,")
+	fmt.fprintln(f, "\tPing_Pong,")
+	fmt.fprintln(f, "\tPing_Pong_Reverse,")
+	fmt.fprintln(f, "}\n")
+	
 	fmt.fprintln(f, "Atlas_Animation :: struct {")
 	fmt.fprintln(f, "\tfirst_frame: Texture_Name,")
 	fmt.fprintln(f, "\tlast_frame: Texture_Name,")
+	fmt.fprintln(f, "\tloop_direction: Tag_Loop_Dir,")
+	fmt.fprintln(f, "\trepeat: u16,")
 	fmt.fprintln(f, "}")
 	fmt.fprintln(f, "")
 
@@ -803,8 +820,8 @@ main :: proc() {
 	fmt.fprint(f, "\t.None = {},\n")
 
 	for a in animations {
-		fmt.fprintf(f, "\t.%v = {{ first_frame = .%v, last_frame = .%v }},\n",
-			a.name, a.first_texture, a.last_texture)
+		fmt.fprintf(f, "\t.%v = {{ first_frame = .%v, last_frame = .%v, loop_direction = .%v, repeat = %v }},\n",
+			a.name, a.first_texture, a.last_texture, a.loop_direction, a.repeat)
 	}
 
 	fmt.fprintln(f, "}\n")

--- a/atlas_builder/atlas_builder.odin
+++ b/atlas_builder/atlas_builder.odin
@@ -247,16 +247,15 @@ load_ase_texture_data :: proc(filename: string, textures: ^[dynamic]Texture_Data
 				
 			case ase.Tags_Chunk:
 				for tag in c {
-				    fmt.println(tag)
-                    a := Animation {
-             			name = fmt.tprint(base_name, tag.name, sep = "_"),
-             			first_texture = fmt.tprint(base_name, tag.from_frame, sep = ""),
-             			last_texture = fmt.tprint(base_name, tag.to_frame, sep = ""),
-                        loop_direction = tag.loop_direction,
-                        repeat = tag.repeat,
-                    }
-                    append(animations, a)
-                }
+					a := Animation {
+						name = fmt.tprint(base_name, tag.name, sep = "_"),
+						first_texture = fmt.tprint(base_name, tag.from_frame, sep = ""),
+						last_texture = fmt.tprint(base_name, tag.to_frame, sep = ""),
+						loop_direction = tag.loop_direction,
+						repeat = tag.repeat,
+					}
+					append(animations, a)
+				}
 			}
 		}
 

--- a/atlas_builder/atlas_builder.odin
+++ b/atlas_builder/atlas_builder.odin
@@ -805,7 +805,8 @@ main :: proc() {
 	fmt.fprintln(f, "\tReverse,")
 	fmt.fprintln(f, "\tPing_Pong,")
 	fmt.fprintln(f, "\tPing_Pong_Reverse,")
-	fmt.fprintln(f, "}\n")
+	fmt.fprintln(f, "}")
+	fmt.fprintln(f, "")
 	
 	fmt.fprintln(f, "Atlas_Animation :: struct {")
 	fmt.fprintln(f, "\tfirst_frame: Texture_Name,")


### PR DESCRIPTION
Added generation of 'repeat' count and 'loop_direction' to fully support Aseprite's tag properties. This can be useful for example to play some animations once (e.g. death animation).

![obraz](https://github.com/user-attachments/assets/e28bda8f-814e-4317-9a2e-7fc322128300)

This will now generate the following code:
![obraz](https://github.com/user-attachments/assets/1bd66c65-9159-4ee0-832b-f122351d3bf3)

.. and it can be used in animation_update like this:
![obraz](https://github.com/user-attachments/assets/bf1eaafa-b735-4aa3-8ced-1456cb7b2592)

I've also extracted generated package name and input texture folder into constants for easier change.