### PR TITLE
Try to copy the raylib.dll with help of 'odin root' on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ I used this kind of hot reloading while developing my game [CAT & ONION](https:/
 If you are on Linux / macOS: Below, replace `.bat` with `.sh` and `.exe` with `.bin`.
 
 1. Run `build_hot_reload.bat` to create `game.exe` and `game.dll`. Note: It expects odin compiler to be part of your PATH environment variable.
-2. Run `game.exe`, leave it running. Note: On Windows you have to copy `raylib.dll` from `your_odin_compiler/vendor/raylib/windows` into this folder.
+2. Run `game.exe`, leave it running. Note: On Windows, if you installed odin through scoop or set an environment variable named `ODIN_ROOT` to the root of your odin install, the script will work out of the box. Otherwise you have to copy `raylib.dll` from `your_odin_compiler/vendor/raylib/windows` into this folder.
 3. Make changes to the gameplay code in `game/game.odin`. For example, change the line `rl.ClearBackground(rl.BLACK)` so that it instead uses `rl.BLUE`. Save the file.
 4. Run `build_hot_reload.bat`, it will recompile `game.dll`.
 5. The running `game.exe` will see that `game.dll` changed and reload it. But it will use the same `Game_Memory` (a struct defined in `game/game.odin`) as before. This will make the game use your new code without having to restart.

--- a/build_hot_reload.bat
+++ b/build_hot_reload.bat
@@ -15,9 +15,21 @@ odin build main_hot_reload -out:game.exe %BUILD_PARAMS%
 IF %ERRORLEVEL% NEQ 0 exit /b 1
 
 rem Warning about raylib DLL not existing and where to find it.
-if not exist "raylib.dll" (
-	echo "Please copy raylib.dll from <your_odin_compiler>/vendor/raylib/windows/raylib.dll to the same directory as game.exe"
-	exit /b 1
+if exist "raylib.dll" (
+	exit /b 0
 )
 
-exit /b 0
+set "ODIN_ROOT="
+
+for /f "delims=" %%i in ('odin root') do (
+    set "ODIN_ROOT=%%i"
+)
+
+if exist "%ODIN_ROOT%\vendor\raylib\windows\raylib.dll" (
+	echo raylib.dll not found in current directory. Copying from %ODIN_ROOT%\vendor\raylib\windows\raylib.dll
+	copy "%ODIN_ROOT%\vendor\raylib\windows\raylib.dll" .
+	exit /b 0
+)
+
+echo "Please copy raylib.dll from <your_odin_compiler>/vendor/raylib/windows/raylib.dll to the same directory as game.exe"
+exit /b 1


### PR DESCRIPTION
This change uses `odin root` on windows as well to figure out where the raylib.dll is.