### PR TITLE
Remove extra game libraries on Linux/macOS

### DIFF
--- a/build_hot_reload.sh
+++ b/build_hot_reload.sh
@@ -39,7 +39,7 @@ odin build game -extra-linker-flags:"$EXTRA_LINKER_FLAGS" -define:RAYLIB_SHARED=
 
 # Need to use a temp file on Linux because it first writes an empty `game.so`, which the game will load before it is actually fully written.
 mv game_tmp$DLL_EXT game$DLL_EXT
-[ -n "$DLL_EXT" ] && rm game_*$DLL_EXT
+[ -n "$DLL_EXT" ] && rm -f game_*$DLL_EXT
 
 # Do not build the game_hot_reload.bin if it is already running.
 # -f is there to make sure we match against full name, including .bin

--- a/build_hot_reload.sh
+++ b/build_hot_reload.sh
@@ -39,6 +39,7 @@ odin build game -extra-linker-flags:"$EXTRA_LINKER_FLAGS" -define:RAYLIB_SHARED=
 
 # Need to use a temp file on Linux because it first writes an empty `game.so`, which the game will load before it is actually fully written.
 mv game_tmp$DLL_EXT game$DLL_EXT
+[ -n "$DLL_EXT" ] && rm game_*$DLL_EXT
 
 # Do not build the game_hot_reload.bin if it is already running.
 # -f is there to make sure we match against full name, including .bin


### PR DESCRIPTION
Hot reloading creates an extra `*$DLL_EXT` file on macOS/Linux and you end up with a lot after reloading. This will delete the `game_*.dylib` files so as to not clutter up the directory.

```
❯ find . -maxdepth 1 -type f -name "game_*.dylib"
./game_3.dylib
./game_1.dylib
./game_0.dylib
./game_2.dylib
```