### PR TITLE
Escape odin root directories with whitespace

### DIFF
--- a/build_hot_reload.bat
+++ b/build_hot_reload.bat
@@ -61,7 +61,7 @@ odin build source\main_hot_reload -strict-style -vet -debug -out:%EXE% -pdb-name
 IF %ERRORLEVEL% NEQ 0 exit /b 1
 
 set ODIN_PATH=
-for /f %%i in ('odin root') do set "ODIN_PATH=%%i"
+for /f "delims=" %%i in ('odin root') do set "ODIN_PATH=%%i"
 
 if not exist "raylib.dll" (
 	if exist "%ODIN_PATH%\vendor\raylib\windows\raylib.dll" (

--- a/build_web.bat
+++ b/build_web.bat
@@ -19,11 +19,11 @@ call %EMSCRIPTEN_SDK_DIR%\emsdk_env.bat
 odin build source\main_web -target:js_wasm32 -build-mode:obj -define:RAYLIB_WASM_LIB=env.o -define:RAYGUI_WASM_LIB=env.o -vet -strict-style -out:%OUT_DIR%\game
 IF %ERRORLEVEL% NEQ 0 exit /b 1
 
-for /f %%i in ('odin root') do set "ODIN_PATH=%%i"
+for /f "delims=" %%i in ('odin root') do set "ODIN_PATH=%%i"
 
-copy %ODIN_PATH%\core\sys\wasm\js\odin.js %OUT_DIR%
+copy "%ODIN_PATH%\core\sys\wasm\js\odin.js" %OUT_DIR%
 
-set files=%OUT_DIR%\game.wasm.o %ODIN_PATH%\vendor\raylib\wasm\libraylib.a %ODIN_PATH%\vendor\raylib\wasm\libraygui.a
+set files=%OUT_DIR%\game.wasm.o "%ODIN_PATH%\vendor\raylib\wasm\libraylib.a" "%ODIN_PATH%\vendor\raylib\wasm\libraygui.a"
 
 :: index_template.html contains the javascript code that calls the procedures in
 :: source/main_web/main_web.odin


### PR DESCRIPTION
The `build_hot_reload.bat` and `build_web.bat` files reading from `odin root` don't handle paths with white-spaces (e.g. `C:\Program Files\odin-windows\`) as `for /f` by default delimitates by space or tab.

Changes:
1. Introduce `"delims="` to the `for /f` loops removing the space delimitation.
2. Wrap usages of `ODIN_PATH` in double quotes to keep spaces escaped.