### PR TITLE
Replace fmt.printf with log.errorf for memory leak reporting

### DIFF
--- a/source/main_hot_reload/main_hot_reload.odin
+++ b/source/main_hot_reload/main_hot_reload.odin
@@ -112,7 +112,7 @@ main :: proc() {
 		err := false
 
 		for _, value in a.allocation_map {
-			fmt.printf("%v: Leaked %v bytes\n", value.location, value.size)
+			log.errorf("%v: Leaked %v bytes\n", value.location, value.size)
 			err = true
 		}
 


### PR DESCRIPTION
similar to main_release.odin

errors are red in the console and look better
