### PR TITLE
Fix macos-arm64 hot reloads

### DIFF
--- a/build_hot_reload.sh
+++ b/build_hot_reload.sh
@@ -16,13 +16,8 @@ ROOT=$(odin root)
 # so libs.
 case $(uname) in
 "Darwin")
-    case $(uname -m) in
-    "arm64") LIB_PATH="macos-arm64" ;;
-    *)       LIB_PATH="macos" ;;
-    esac
-
     DLL_EXT=".dylib"
-    EXTRA_LINKER_FLAGS="-Wl,-rpath $ROOT/vendor/raylib/$LIB_PATH"
+    EXTRA_LINKER_FLAGS="-Wl,-rpath $ROOT/vendor/raylib/macos"
     ;;
 *)
     DLL_EXT=".so"


### PR DESCRIPTION
## Problem

Hot reload builds fail to link raylib dylibs on new versions of Odin on macos-arm64. In https://github.com/odin-lang/Odin/pull/4512, `/macos-arm64/libraylib.500.dylib` was removed infavor of the universal macos `/macos/libraylib.500.dylib`.