### PR TITLE
fix: temp allocator parameter not needed for filepath.dir

### DIFF
--- a/source/main_hot_reload/main_hot_reload.odin
+++ b/source/main_hot_reload/main_hot_reload.odin
@@ -98,7 +98,7 @@ unload_game_api :: proc(api: ^Game_API) {
 main :: proc() {
 	// Set working dir to dir of executable.
 	exe_path := os.args[0]
-	exe_dir := filepath.dir(string(exe_path), context.temp_allocator)
+	exe_dir := filepath.dir(string(exe_path))
 	os.set_working_directory(exe_dir)
 
 	context.logger = log.create_console_logger()

--- a/source/main_release/main_release.odin
+++ b/source/main_release/main_release.odin
@@ -17,7 +17,7 @@ USE_TRACKING_ALLOCATOR :: #config(USE_TRACKING_ALLOCATOR, false)
 main :: proc() {
 	// Set working dir to dir of executable.
 	exe_path := os.args[0]
-	exe_dir := filepath.dir(string(exe_path), context.temp_allocator)
+	exe_dir := filepath.dir(string(exe_path))
 	os.set_working_directory(exe_dir)
 	
 	mode := os.Permissions { .Read_User, .Write_User, .Read_Group, .Read_Other }


### PR DESCRIPTION
filepath.dir no longer takes allocator parameter

See https://github.com/odin-lang/Odin/pull/6575