### PR TITLE
Keep hot-reload console window open only on crash/leak, not on clean exit

### DIFF
--- a/build_hot_reload.bat
+++ b/build_hot_reload.bat
@@ -74,8 +74,12 @@ if not exist "raylib.dll" (
 	)
 )
 
+:: Run the game in its own console window. On a normal exit (code 0) the
+:: window closes right away. On a bad exit (crash, panic, or a memory leak
+:: reported at shutdown) the window stays open with an interactive prompt so
+:: you can read the output, instead of it disappearing immediately.
 if "%~1"=="run" (
 	echo Running %EXE%...
-	start %EXE%
+	start "" cmd /c "%EXE% || (echo. & echo ---- %EXE% exited with an error, see output above. Window stays open. ---- & cmd)"
 )
 

--- a/source/main_hot_reload/main_hot_reload.odin
+++ b/source/main_hot_reload/main_hot_reload.odin
@@ -7,7 +7,6 @@ package main
 
 import "core:dynlib"
 import "core:fmt"
-import "core:c/libc"
 import "core:os"
 import "core:log"
 import "core:mem"
@@ -192,22 +191,13 @@ main :: proc() {
 				log.errorf("Bad free at: %v", b.location)
 			}
 
-			// This prevents the game from closing without you seeing the bad
-			// frees. This is mostly needed because I use Sublime Text and my game's
-			// console isn't hooked up into Sublime's console properly.
-			libc.getchar()
 			panic("Bad free detected")
 		}
 	}
 
 	free_all(context.temp_allocator)
 	game_api.shutdown()
-	if reset_tracking_allocator(&tracking_allocator) {
-		// This prevents the game from closing without you seeing the memory
-		// leaks. This is mostly needed because I use Sublime Text and my game's
-		// console isn't hooked up into Sublime's console properly.
-		libc.getchar()
-	}
+	leaked := reset_tracking_allocator(&tracking_allocator)
 
 	for &g in old_game_apis {
 		unload_game_api(&g)
@@ -218,6 +208,15 @@ main :: proc() {
 	game_api.shutdown_window()
 	unload_game_api(&game_api)
 	mem.tracking_allocator_destroy(&tracking_allocator)
+
+	// Exit with a non-zero code on a leak so the wrapping console window
+	// (see build_hot_reload.bat) stays open instead of closing immediately,
+	// letting you read the leak report above.
+	//
+	// Windows-only thing for now.
+	if leaked {
+		os.exit(1)
+	}
 }
 
 // Make game use good GPU on laptops.


### PR DESCRIPTION
## What changed

- `build_hot_reload.bat`: the game now runs via `start "" cmd /c "%EXE% || (... & cmd)"` instead of plain `start %EXE%`. On a clean exit (code 0) the console window closes immediately, same as before. On a non-zero exit (crash, panic, or a detected memory leak) it prints a short marker and drops into an interactive `cmd` prompt so the window stays open for you to read the output.
- `source/main_hot_reload/main_hot_reload.odin`: removed the `libc.getchar()` pause hack (and the now-unused `core:c/libc` import) that used to keep the window from disappearing before you could read shutdown output. A detected leak now makes the process exit with code 1 (via `os.exit(1)`) so the batch script's fallback branch kicks in; a bad free already panics, which already produces a non-zero exit code.

## Why

Closes #24. `main_hot_reload.exe` is launched via `start` so it gets its own console window, separate from Sublime's build output panel — that's what lets you trigger a hot reload from Sublime without killing the running game. But that window used to close instantly the moment the exe exited, taking any shutdown-time output (in particular memory leak reports) with it. The old fix was a `getchar()` call that always paused shutdown waiting for a keypress, which was flagged as ugly in #24 and also stayed open even on a totally clean exit with nothing to read.

Now the window only lingers when there's actually something worth reading.

## Testing

- Confirmed `build_hot_reload.bat run` builds and launches without a batch parsing error.
- Confirmed the `cmd /c "... || (...)"` fallback: with a stand-in command exiting 0, the fallback branch is skipped and the window closes; with a stand-in command exiting 1, the fallback branch runs and drops into an interactive prompt.
- Confirmed `source/main_hot_reload` still compiles after removing the `libc` import and the `getchar()` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)